### PR TITLE
[refactor] : RefreshToken 필드명 관련 코드 수정

### DIFF
--- a/src/main/java/edu/sookmyung/talktitude/client/model/Order.java
+++ b/src/main/java/edu/sookmyung/talktitude/client/model/Order.java
@@ -21,7 +21,7 @@ public class Order {
     @JoinColumn(name = "client_id", nullable = false)
     private Client client;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 

--- a/src/main/java/edu/sookmyung/talktitude/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/edu/sookmyung/talktitude/token/repository/RefreshTokenRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByMemberIdAndUserType(Long id, String userType);
+    Optional<RefreshToken> findByUserIdAndUserType(Long id, String userType);
 }

--- a/src/main/java/edu/sookmyung/talktitude/token/service/RefreshTokenService.java
+++ b/src/main/java/edu/sookmyung/talktitude/token/service/RefreshTokenService.java
@@ -17,7 +17,7 @@ public class RefreshTokenService {
 
     public RefreshToken createRefreshToken(BaseUser baseUser){
         //기존 리프레시 토큰 찾기
-        RefreshToken refreshToken = refreshTokenRepository.findByMemberIdAndUserType(baseUser.getId(),baseUser.getUserType())
+        RefreshToken refreshToken = refreshTokenRepository.findByUserIdAndUserType(baseUser.getId(),baseUser.getUserType())
                 .orElse(new RefreshToken(baseUser.getId(),null,baseUser.getUserType()));
 
         String newToken = tokenProvider.generateRefreshToken(baseUser);


### PR DESCRIPTION
## 📌 관련 이슈
이미 닫힌 이슈


## ✅ 작업 내용
- RefreshToken 필드명 memberId를 변경


## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/d13fbea3-9248-4649-a3ce-8adb674f3abb)


## 💬 리뷰 참고 사항
- [ ] RefreshToken 필드명이 memberId로 한정되어 있어서 client, member 모두를 포함하는 userId로 변경 > 관련 코드들 수정
- [ ] 현재 로그인 이슈와는 관련이 없지만 Order가 Restaurant와 일대일 관계 > 일대다 관계로 변경
