### PR TITLE
feat: 상담원 상담 목록 조회 

### DIFF
--- a/src/main/java/edu/sookmyung/talktitude/token/model/RefreshToken.java
+++ b/src/main/java/edu/sookmyung/talktitude/token/model/RefreshToken.java
@@ -7,13 +7,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 @Entity
+@Table(
+        name = "refresh_token",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "user_type"})
+        }
+)
 public class RefreshToken {
 
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name="user_id",nullable=false,unique=true)
+    @Column(name="user_id",nullable=false)
     private Long userId;
 
     @Column(name="refresh_token",nullable = false)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 상담원의 상담 목록 조회 
- RefreshToken unique 제약 조건 변경
-  TokenProvider 수정

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
<img width="2571" height="1510" alt="스크린샷 2025-07-17 161557" src="https://github.com/user-attachments/assets/fe96dfe0-bf63-4c75-8636-cac776899667" />


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
- refresh_token 테이블의 userId가 유니크라 id 1번 고객이랑 id 1번 상담원이 로그인하면 에러남. user_id + user_type를 복합 유니크 제약조건으로 수정함