### PR TITLE
feat : 메모 조회 기능 구현

### DIFF
--- a/src/main/java/edu/sookmyung/talktitude/client/controller/ClientController.java
+++ b/src/main/java/edu/sookmyung/talktitude/client/controller/ClientController.java
@@ -6,10 +6,18 @@ import edu.sookmyung.talktitude.client.dto.OrderDetailInfo;
 import edu.sookmyung.talktitude.client.dto.OrderInfo;
 import edu.sookmyung.talktitude.client.service.ClientService;
 import edu.sookmyung.talktitude.common.response.ApiResponse;
+import edu.sookmyung.talktitude.common.response.PageResponse;
 import edu.sookmyung.talktitude.member.dto.LoginRequest;
 import edu.sookmyung.talktitude.member.dto.LoginResponse;
 import edu.sookmyung.talktitude.member.model.Member;
+import edu.sookmyung.talktitude.memo.dto.MemoResponse;
+import edu.sookmyung.talktitude.report.dto.ReportDetailByClient;
+import edu.sookmyung.talktitude.report.dto.ReportListByClient;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -58,6 +66,27 @@ public class ClientController {
                                                                        @PathVariable String orderNumber) {
         OrderDetailInfo orderDetailInfo = clientService.getOrderDetailById(orderNumber,member,sessionId);
         return ResponseEntity.ok(ApiResponse.ok(orderDetailInfo));
+    }
+
+    //오른쪽 정보 패널 -> 고객별 상담 목록 조회
+    @GetMapping("/{sessionId}/reports")
+    public ResponseEntity<PageResponse<ReportListByClient>> getReportListByClient(@PathVariable Long sessionId, @PageableDefault(size=10, sort="createdAt",direction = Sort.Direction.ASC) Pageable pageable, @AuthenticationPrincipal Member member) {
+        Page<ReportListByClient> reportListByClients = clientService.getReportsByClient(sessionId,member,pageable);
+        return ResponseEntity.ok(PageResponse.of(reportListByClients));
+    }
+
+    //오른쪽 정보 패널 -> 고객별 상담 상세 내용 조회
+    @GetMapping("{sessionId}/reports/detail/{reportId}")
+    public ResponseEntity<ReportDetailByClient> getReportDetailByClient(@PathVariable Long sessionId, @PathVariable Long reportId, @AuthenticationPrincipal Member member) {
+        ReportDetailByClient reportDetailByClient = clientService.getReportDetailByClient(reportId,sessionId,member);
+        return ResponseEntity.ok(reportDetailByClient);
+    }
+
+    //오른쪽 정보 패널 -> 상담 중에 작성된 메모만 조회
+    @GetMapping("/{sessionId}/during-chats")
+    public ResponseEntity<List<MemoResponse>> getDuringChatUserMemos(@PathVariable Long sessionId, @AuthenticationPrincipal Member member) {
+        List<MemoResponse> reportMemos = clientService.getDuringChatUserMemos(sessionId,member);
+        return ResponseEntity.ok().body(reportMemos);
     }
 
 }

--- a/src/main/java/edu/sookmyung/talktitude/common/exception/ErrorCode.java
+++ b/src/main/java/edu/sookmyung/talktitude/common/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_001", "리포트 정보를 찾을 수 없습니다."),
     REPORT_JSON_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REPORT_002","리포트 생성 중 JSON 처리에 실패하였습니다"),
     GPT_API_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "REPORT_003", "GPT AI 서비스 호출에 실패했습니다."),
+    UNAUTHORIZED_CLIENT_ACCESS(HttpStatus.FORBIDDEN, "REPORT_004", "해당 고객의 상담 내용에 접근할 권한이 없습니다."),
 
     //Memo 관련
     MEMO_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMO_001", "메모 정보를 찾을 수 없습니다."),

--- a/src/main/java/edu/sookmyung/talktitude/memo/dto/MemoRequest.java
+++ b/src/main/java/edu/sookmyung/talktitude/memo/dto/MemoRequest.java
@@ -1,11 +1,6 @@
 package edu.sookmyung.talktitude.memo.dto;
 
-import edu.sookmyung.talktitude.report.model.Memo;
-import edu.sookmyung.talktitude.report.model.MemoPhase;
 import lombok.*;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/edu/sookmyung/talktitude/memo/repository/MemoRepository.java
+++ b/src/main/java/edu/sookmyung/talktitude/memo/repository/MemoRepository.java
@@ -8,11 +8,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MemoRepository extends JpaRepository<Memo, Long> {
     List<Memo> findByChatSessionAndMemoPhase(ChatSession chatSession, MemoPhase memoPhase);
-    Memo findByChatSessionAndMemberAndMemoPhase(ChatSession chatSession, Member currentMember, MemoPhase memoPhase);
-    Memo findByChatSession(ChatSession chatSession);
+    List<Memo> findByChatSessionAndMemberAndMemoPhase(ChatSession chatSession, Member currentMember, MemoPhase memoPhase);
+    Optional<Memo> findDuringChatByChatSessionAndMemberAndMemoPhase(ChatSession chatSession, Member member, MemoPhase memoPhase);
+
 }
 

--- a/src/main/java/edu/sookmyung/talktitude/report/controller/ReportController.java
+++ b/src/main/java/edu/sookmyung/talktitude/report/controller/ReportController.java
@@ -30,20 +30,6 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    //고객별 상담 목록 조회
-    @GetMapping("/client/{sessionId}")
-    public ResponseEntity<PageResponse<ReportListByClient>> getReportListByClient(@PathVariable Long sessionId,@PageableDefault(size=10, sort="createdAt",direction = Sort.Direction.ASC) Pageable pageable, @AuthenticationPrincipal Member member) {
-        Page<ReportListByClient> reportListByClients = reportService.getReportsByClient(sessionId,pageable);
-        return ResponseEntity.ok(PageResponse.of(reportListByClients));
-    }
-
-    //고객별 상담 상세 내용 조회
-    @GetMapping("/client/detail/{reportId}")
-    public ResponseEntity<ReportDetailByClient> getReportDetailByClient(@PathVariable Long reportId, @AuthenticationPrincipal Member member) {
-        ReportDetailByClient reportDetailByClient = reportService.getReportDetailByClient(reportId);
-        return ResponseEntity.ok(reportDetailByClient);
-    }
-
     //날짜별 상담 목록 조회
     @GetMapping
     public ResponseEntity<PageResponse<ReportList>> getReportListsByDate(@RequestParam @DateTimeFormat(pattern="yyyy-MM-dd") LocalDate date,@PageableDefault(size=10, sort="createdAt") Pageable pageable,@AuthenticationPrincipal Member member) {

--- a/src/main/java/edu/sookmyung/talktitude/report/service/ReportService.java
+++ b/src/main/java/edu/sookmyung/talktitude/report/service/ReportService.java
@@ -11,6 +11,8 @@ import edu.sookmyung.talktitude.chat.repository.ChatSessionRepository;
 import edu.sookmyung.talktitude.common.exception.BaseException;
 import edu.sookmyung.talktitude.common.exception.ErrorCode;
 import edu.sookmyung.talktitude.config.ai.GPTProperties;
+import edu.sookmyung.talktitude.memo.dto.MemoResponse;
+import edu.sookmyung.talktitude.memo.service.MemoService;
 import edu.sookmyung.talktitude.report.dto.*;
 import edu.sookmyung.talktitude.report.model.Category;
 import edu.sookmyung.talktitude.report.model.Report;
@@ -43,7 +45,7 @@ public class ReportService {
     private final ChatSessionRepository chatSessionRepository;
     private final GPTProperties gptProperties;
     private final ObjectMapper objectMapper;
-    //private final MemoService memoService;
+    private final MemoService memoService;
 
 
     @Transactional
@@ -162,11 +164,8 @@ public class ReportService {
     // 상담 상세 내용 조회
     public ReportDetail getReportDetail(Long reportId) {
         Report report = reportRepository.findById(reportId).orElseThrow(() -> new BaseException(ErrorCode.REPORT_NOT_FOUND));
-
-        //List<ReportMemo> reportMemos = memoService.getMemos(report.getId());
-
-        //return ReportDetail.convertToReportDetail(report,reportMemos);
-        return ReportDetail.convertToReportDetail(report,Collections.emptyList());
+        List<MemoResponse> reportMemos = memoService.getMemos(report.getId());
+        return ReportDetail.convertToReportDetail(report,reportMemos);
     }
 
     //사용자 이름 검색을 통한 상담 목록 조회
@@ -175,20 +174,4 @@ public class ReportService {
                 .map(ReportList::convertToDto);
     }
 
-    // 고객별 상담 목록 조회 - 우측 패널용
-    public Page<ReportListByClient> getReportsByClient(Long sessionId,Pageable pageable) {
-        ChatSession chatSession = chatSessionRepository.findById(sessionId).orElseThrow(() -> new BaseException(ErrorCode.CHATSESSION_NOT_FOUND));
-        return reportRepository.findByClientLoginId(chatSession.getClient().getLoginId(),pageable)
-                .map(ReportListByClient::convertToReportListByClient);
-
-    }
-
-    // 고객별 상담 상세 조회 - 우측 패널용
-    public ReportDetailByClient getReportDetailByClient(Long reportId) {
-
-        return reportRepository.findById(reportId)
-                .map(ReportDetailByClient::convertToReportDetailByClient)
-                .orElseThrow(()-> new BaseException(ErrorCode.REPORT_NOT_FOUND));
-
-    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #34 


## ✅ 작업 내용
- 리포트 화면에서 메모 조회(상담 중 + 상담 이후)
- 오른쪽 패널에서 메모 조회(상담 중 작성된 메모 대상)


## 📸 스크린샷(선택)
- 오른쪽 패널에서 메모 조회
<img width="537" height="626" alt="image" src="https://github.com/user-attachments/assets/05fba2d0-7eec-46b9-ad5a-0079e6981077" />
- 리포트 화면에서 메모 조회
<img width="732" height="1237" alt="image" src="https://github.com/user-attachments/assets/2796a662-b13e-443b-8820-556269432959" />


## 💬 리뷰 참고 사항
기존 도메인별 API 구조에서 프론트엔드 개발 효율성과 검증 코드 일관성을 위해 화면 단위로 API 재구성