### PR TITLE
40 feat 채팅 내역 불러오기

### DIFF
--- a/src/main/java/edu/sookmyung/talktitude/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/edu/sookmyung/talktitude/chat/dto/ChatMessageResponse.java
@@ -1,5 +1,6 @@
 package edu.sookmyung.talktitude.chat.dto;
 
+import edu.sookmyung.talktitude.chat.model.ChatMessage;
 import edu.sookmyung.talktitude.chat.model.SenderType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,8 +12,28 @@ import java.time.LocalDateTime;
 // 클라이언트에게 전달될 메시지
 public class ChatMessageResponse {
     private Long messageId;
-    private String originalText;
-    private String convertedText;
+    private String textToShow;    // 화면에 보여지는 텍스트(상담원: 원문, 고객: 공손화된 메시지 or 원문(공손화 필요X 경우))
+    private String originalText;  // 원문 텍스트(고객이 직접 입력한 것, 공손화된 경우에만 제공)
+    private boolean showOriginal; // 원문보기 버튼 표시 여부
     private String senderType;
     private LocalDateTime createdAt;
+
+    public ChatMessageResponse(ChatMessage message, String userType) {
+        this.messageId = message.getId();
+        this.originalText = message.getOriginalText();
+        this.senderType = message.getSenderType().name();
+        this.createdAt = message.getCreatedAt();
+
+        if ("MEMBER".equalsIgnoreCase(userType)) {
+            // 상담원 화면: 공손화가 있으면 공손문, 없으면 원문
+            this.textToShow  = (message.getConvertedText() != null)
+                    ? message.getConvertedText()
+                    : message.getOriginalText();
+            this.showOriginal = (message.getConvertedText() != null); // 상담원만 원문보기 버튼
+        } else {
+            // 고객 화면: 항상 본인이 쓴 원문만
+            this.textToShow  = message.getOriginalText();
+            this.showOriginal = false;
+        }
+    }
 }

--- a/src/main/java/edu/sookmyung/talktitude/chat/service/ChatService.java
+++ b/src/main/java/edu/sookmyung/talktitude/chat/service/ChatService.java
@@ -168,5 +168,24 @@ public class ChatService {
         return chatMessageRepository.save(message);
     }
 
+    // 채팅 내역 조회
+    @Transactional(readOnly = true)
+    public List<ChatMessage> findChatMessagesWithAccessCheck(Long sessionId, Long userId, String userType) {
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BaseException(ErrorCode.CHATSESSION_NOT_FOUND));
+
+        boolean isAuthorized = false;
+        if ("Member".equalsIgnoreCase(userType)) {
+            isAuthorized = session.getMember().getId().equals(userId);
+        } else if ("Client".equalsIgnoreCase(userType)) {
+            isAuthorized = session.getClient().getId().equals(userId);
+        }
+
+        if (!isAuthorized) {
+            throw new BaseException(ErrorCode.CHATSESSION_ACCESS_DENIED);
+        }
+
+        return chatMessageRepository.findByChatSessionIdOrderByCreatedAtAsc(sessionId);
+    }
 
 }

--- a/src/main/java/edu/sookmyung/talktitude/common/exception/ErrorCode.java
+++ b/src/main/java/edu/sookmyung/talktitude/common/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     //ChatSession 관련
     CHATSESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATSESSION_001", "세션 정보를 찾을 수 없습니다."),
     INVALID_SESSION_STATE(HttpStatus.BAD_REQUEST, "CHATSESSION_002", "이미 종료된 상담 세션입니다."),
+    CHATSESSION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CHATSESSION_003", "해당 세션에 접근할 권한이 없습니다."),
 
     // Order 관련
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_O01", "주문을 찾을 수 없습니다."),

--- a/src/main/java/edu/sookmyung/talktitude/config/jwt/TokenProvider.java
+++ b/src/main/java/edu/sookmyung/talktitude/config/jwt/TokenProvider.java
@@ -116,8 +116,11 @@ public class TokenProvider {
     }
 
     // 웹소켓 관련 코드
-    public Long getMemberId(String token) {
-        Claims claims = getClaims(token);
-        return Long.valueOf(claims.get("id").toString());
+    public String getLoginId(String token) {
+        return Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretKey())
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject(); // subject = loginId
     }
 }

--- a/src/main/java/edu/sookmyung/talktitude/config/websocket/CustomHandshakeHandler.java
+++ b/src/main/java/edu/sookmyung/talktitude/config/websocket/CustomHandshakeHandler.java
@@ -1,0 +1,19 @@
+package edu.sookmyung.talktitude.config.websocket;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
+
+@Component
+public class CustomHandshakeHandler extends DefaultHandshakeHandler {
+    @Override
+    protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler,
+                                      Map<String, Object> attributes) {
+        String loginId = (String) attributes.get("loginId");
+        return () -> loginId; // Principal::getName
+    }
+}

--- a/src/main/java/edu/sookmyung/talktitude/config/websocket/HandShakeInterceptor.java
+++ b/src/main/java/edu/sookmyung/talktitude/config/websocket/HandShakeInterceptor.java
@@ -17,22 +17,19 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
     private final TokenProvider tokenProvider;
 
     @Override
-    public boolean beforeHandshake(ServerHttpRequest request,
-                                   ServerHttpResponse response,
-                                   WebSocketHandler wsHandler,
-                                   Map<String, Object> attributes) throws Exception {
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) {
 
-        var headers = request.getHeaders();
-        String auth = headers.getFirst("Authorization"); // "Bearer xxx"
+        String auth  = request.getHeaders().getFirst("Authorization");
         String token = (auth != null && auth.startsWith("Bearer ")) ? auth.substring(7) : null;
 
         if (token != null && tokenProvider.validToken(token)) {
-            Long memberId = tokenProvider.getMemberId(token);
-            attributes.put("memberId", memberId);
+            attributes.put("userId",   tokenProvider.getUserId(token));     // Long
+            attributes.put("userType", tokenProvider.getUserType(token));   // "Member"/"Client"
+            attributes.put("loginId",  tokenProvider.getLoginId(token));    // String (Principal용)
             return true;
         }
-
-        return false; // 유효하지 않으면 거절
+        return false;
     }
 
     @Override

--- a/src/main/java/edu/sookmyung/talktitude/config/websocket/WebSocketConfig.java
+++ b/src/main/java/edu/sookmyung/talktitude/config/websocket/WebSocketConfig.java
@@ -15,20 +15,23 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final HandShakeInterceptor handShakeInterceptor;
     private final StompHandler stompHandler;
+    private final CustomHandshakeHandler customHandshakeHandler;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // WebSocket 연결 endpoint
         registry.addEndpoint("/ws")
                 .addInterceptors(handShakeInterceptor)
+                .setHandshakeHandler(customHandshakeHandler) // Principal 주입
                 .setAllowedOrigins("*")
                 .withSockJS();
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/topic"); // 구독 주소 (메시지를 구독(수신)하는 요청 엔드포인트)
+        registry.enableSimpleBroker("/topic", "/queue"); // 구독 주소 (메시지를 구독(수신)하는 요청 엔드포인트)
         registry.setApplicationDestinationPrefixes("/app"); // 발신 주소 (메시지를 발행(송신)하는 엔드포인트)
+        registry.setUserDestinationPrefix("/user");
     }
 
     @Override


### PR DESCRIPTION
## 📌 관련 이슈
  closed #40 


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 채팅 내역 조회 API: 해당 세션의 모든 메시지 조회
- WebSocket 로직 수정: 상담원과 고객에게 서로 다른 payload 전송을 위해 기존 브로드캐스트 방식 -> 큐 방식으로 변경하였습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
