### PR TITLE
[FEAT] 주문 목록 조회 기능 구현

### DIFF
--- a/src/main/java/edu/sookmyung/talktitude/chat/controller/ChatController.java
+++ b/src/main/java/edu/sookmyung/talktitude/chat/controller/ChatController.java
@@ -1,11 +1,9 @@
 package edu.sookmyung.talktitude.chat.controller;
 
-import edu.sookmyung.talktitude.chat.dto.ChatMessageResponse;
-import edu.sookmyung.talktitude.chat.dto.ChatSessionDetailDto;
-import edu.sookmyung.talktitude.chat.dto.ChatSessionDto;
-import edu.sookmyung.talktitude.chat.dto.CreateSessionRequest;
+import edu.sookmyung.talktitude.chat.dto.*;
 import edu.sookmyung.talktitude.chat.model.ChatMessage;
 import edu.sookmyung.talktitude.chat.service.ChatService;
+import edu.sookmyung.talktitude.client.model.Client;
 import edu.sookmyung.talktitude.common.response.ApiResponse;
 import edu.sookmyung.talktitude.member.model.BaseUser;
 import edu.sookmyung.talktitude.member.model.Member;
@@ -31,6 +29,13 @@ public class ChatController {
     public ResponseEntity<ApiResponse<Map<String, Long>>> createSession(@RequestBody CreateSessionRequest request) {
         Long sessionId = chatService.createChatSession(request);
         return ResponseEntity.ok(ApiResponse.ok(Map.of("sessionId", sessionId), "상담 세션이 생성되었습니다."));
+    }
+
+    //고객 - 상담 전 주문 목록 조회
+    @GetMapping("/orders")
+    public ResponseEntity<ApiResponse<List<OrderHistory>>> getOrderHistory(@AuthenticationPrincipal Client client){
+        List<OrderHistory> orderHistoryList = chatService.getOrderHistory(client);
+        return ResponseEntity.ok(ApiResponse.ok(orderHistoryList));
     }
 
     // 상담원 - 상담 목록 조회
@@ -91,5 +96,7 @@ public class ChatController {
                 chatService.searchByClientLoginId(member.getId(), keyword, status);
         return ResponseEntity.ok(ApiResponse.ok(list, "채팅방 검색 성공"));
     }
+
+
 
 }

--- a/src/main/java/edu/sookmyung/talktitude/chat/dto/OrderHistory.java
+++ b/src/main/java/edu/sookmyung/talktitude/chat/dto/OrderHistory.java
@@ -1,0 +1,13 @@
+package edu.sookmyung.talktitude.chat.dto;
+
+//TODO Order의 orderNumber가 중복이 없다는 것을 비즈니스로직 차원에서만 가정해도 옳은가
+public record OrderHistory(
+        Long orderId,
+        String restaurantImageUrl,
+        String restaurantName,
+        String MainMenu,
+        int menuCount,
+        int paidAmount,
+        String orderDate
+) {
+}

--- a/src/main/java/edu/sookmyung/talktitude/client/controller/ClientController.java
+++ b/src/main/java/edu/sookmyung/talktitude/client/controller/ClientController.java
@@ -4,6 +4,7 @@ import edu.sookmyung.talktitude.client.dto.ClientDto;
 import edu.sookmyung.talktitude.client.dto.ClientInfo;
 import edu.sookmyung.talktitude.client.dto.OrderDetailInfo;
 import edu.sookmyung.talktitude.client.dto.OrderInfo;
+import edu.sookmyung.talktitude.client.model.Client;
 import edu.sookmyung.talktitude.client.service.ClientService;
 import edu.sookmyung.talktitude.common.response.ApiResponse;
 import edu.sookmyung.talktitude.common.response.PageResponse;
@@ -43,7 +44,6 @@ public class ClientController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    /* 해당 채팅에 참가한 회원만 조회 가능하도록 구현 , */
     //오른쪽 정보 패널 -> 고객 정보 조회
     @GetMapping("/{sessionId}/client-info")
     public ResponseEntity<ApiResponse<ClientInfo>> getClientInfo(@AuthenticationPrincipal Member member, @PathVariable Long sessionId){

--- a/src/main/java/edu/sookmyung/talktitude/client/model/Order.java
+++ b/src/main/java/edu/sookmyung/talktitude/client/model/Order.java
@@ -1,5 +1,6 @@
 package edu.sookmyung.talktitude.client.model;
 
+import edu.sookmyung.talktitude.chat.dto.OrderHistory;
 import edu.sookmyung.talktitude.chat.model.ChatSession;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -35,4 +36,13 @@ public class Order {
 
     @OneToMany(mappedBy = "order")
     private List<ChatSession> chatSessions;
+
+    @OneToMany(mappedBy="order",fetch = FetchType.EAGER)
+    private List<OrderMenu> orderMenus;
+
+    @OneToOne(fetch = FetchType.EAGER)
+    private OrderPayment orderPayment;
+
+    @OneToOne(fetch = FetchType.EAGER)
+    private OrderDelivery orderDelivery;
 }

--- a/src/main/java/edu/sookmyung/talktitude/client/service/ClientService.java
+++ b/src/main/java/edu/sookmyung/talktitude/client/service/ClientService.java
@@ -137,7 +137,11 @@ public class ClientService {
         // 배달 정보와 함께 orderInfo dto 구성
         return orders.stream()
                 .map(order->{
-                    OrderDelivery orderDelivery = orderDeliveryRepository.findByOrder(order).orElseThrow(() -> new BaseException(ErrorCode.ORDER_DELIVERY_NOT_FOUND));
+                    OrderDelivery orderDelivery = order.getOrderDelivery();
+
+                    if(orderDelivery==null){
+                        throw new BaseException(ErrorCode.ORDER_DELIVERY_NOT_FOUND);
+                    }
                     return OrderInfo.convertToOrderInfo(order, orderDelivery);
                 }).collect(Collectors.toList());
     }
@@ -158,12 +162,20 @@ public class ClientService {
             throw new BaseException(ErrorCode.ORDER_ACCESS_DENIED);
         }
 
-        OrderDelivery orderDelivery = orderDeliveryRepository.findByOrder(order)
-                .orElseThrow(() -> new BaseException(ErrorCode.ORDER_DELIVERY_NOT_FOUND));
+        OrderDelivery orderDelivery = order.getOrderDelivery();
+        if(orderDelivery==null){
+            throw new BaseException(ErrorCode.ORDER_DELIVERY_NOT_FOUND);
+        }
 
-        OrderPayment orderPayment = orderPaymentRepository.findByOrder(order)
-                .orElseThrow(() -> new BaseException(ErrorCode.ORDER_PAYMENT_NOT_FOUND));
-        List<OrderMenu> orderMenus = orderMenuRepository.findByOrder(order);
+        OrderPayment orderPayment = order.getOrderPayment();
+        if(orderPayment==null){
+            throw new BaseException(ErrorCode.ORDER_PAYMENT_NOT_FOUND);
+        }
+
+        List<OrderMenu> orderMenus = order.getOrderMenus();
+        if(orderMenus.isEmpty()){
+            throw new BaseException(ErrorCode.ORDER_MENU_NOT_FOUND);
+        }
 
         return OrderDetailInfo.convertToOrderDetailInfo(order, orderDelivery, orderPayment, orderMenus);
     }

--- a/src/main/java/edu/sookmyung/talktitude/common/exception/ErrorCode.java
+++ b/src/main/java/edu/sookmyung/talktitude/common/exception/ErrorCode.java
@@ -39,8 +39,9 @@ public enum ErrorCode {
     // Order 관련
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_O01", "주문을 찾을 수 없습니다."),
     ORDER_DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_O02", "배달 정보를 찾을 수 없습니다."),
-    ORDER_PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_O03", "결제 정보를 찾을 수 없습니다."),
-    ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ORDER_O04", "해당 주문에 접근할 권한이 없습니다."),
+    ORDER_MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_O03", "메뉴 정보를 찾을 수 없습니다."),
+    ORDER_PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_O04", "결제 정보를 찾을 수 없습니다."),
+    ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ORDER_O05", "해당 주문에 접근할 권한이 없습니다."),
 
     //Report 관련
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_001", "리포트 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 관련 이슈
#44 


## ✅ 작업 내용
고객 화면에서 상담하기 전 어떤 주문에 대한 상담을 생성할 것인지 선택할 때, 고객의 전체 주문 목록 조회 기능 구현

## 📸 스크린샷(선택)
<img width="797" height="935" alt="image" src="https://github.com/user-attachments/assets/4ac30ff7-fd4b-4368-a8be-f93259c3cf81" />


## 💬 리뷰 참고 사항
Order에 연관관계를 매핑하여 불필요한 DB호출 코드 수정함
