### PR TITLE
[FIX] 피드백 관련 수정 

### DIFF
--- a/src/main/java/edu/sookmyung/talktitude/client/controller/ClientController.java
+++ b/src/main/java/edu/sookmyung/talktitude/client/controller/ClientController.java
@@ -10,7 +10,6 @@ import edu.sookmyung.talktitude.member.dto.LoginRequest;
 import edu.sookmyung.talktitude.member.dto.LoginResponse;
 import edu.sookmyung.talktitude.member.model.Member;
 import edu.sookmyung.talktitude.memo.dto.MemoResponse;
-import edu.sookmyung.talktitude.report.dto.ReportDetailByClient;
 import edu.sookmyung.talktitude.report.dto.ReportListByClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -66,13 +65,6 @@ public class ClientController {
     public ResponseEntity<ApiResponse<List<ReportListByClient>>> getReportListByClient(@PathVariable Long sessionId, @AuthenticationPrincipal Member member) {
         List<ReportListByClient> reportListByClients = clientService.getReportsByClient(sessionId,member);
         return ResponseEntity.ok(ApiResponse.ok(reportListByClients));
-    }
-
-    //오른쪽 정보 패널 -> 고객별 상담 상세 내용 조회
-    @GetMapping("{sessionId}/reports/detail/{reportId}")
-    public ResponseEntity<ApiResponse<ReportDetailByClient>> getReportDetailByClient(@PathVariable Long sessionId, @PathVariable Long reportId, @AuthenticationPrincipal Member member) {
-        ReportDetailByClient reportDetailByClient = clientService.getReportDetailByClient(reportId,sessionId,member);
-        return ResponseEntity.ok(ApiResponse.ok(reportDetailByClient));
     }
 
     //오른쪽 정보 패널 -> 상담 중에 작성된 메모만 조회

--- a/src/main/java/edu/sookmyung/talktitude/config/security/SecurityConfig.java
+++ b/src/main/java/edu/sookmyung/talktitude/config/security/SecurityConfig.java
@@ -100,7 +100,9 @@ public class SecurityConfig {
 
         config.setAllowedOrigins(List.of(
                 "http://localhost:3000",
-                "http://127.0.0.1:3000"
+                "http://localhost:3001",
+                "http://127.0.0.1:3000",
+                "http://127.0.0.1:3001"
         ));
         config.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
         config.setAllowedHeaders(List.of("*"));

--- a/src/main/java/edu/sookmyung/talktitude/report/dto/ReportDetail.java
+++ b/src/main/java/edu/sookmyung/talktitude/report/dto/ReportDetail.java
@@ -10,6 +10,7 @@ import java.util.List;
 public record ReportDetail (
      Long id,
      String clientName,
+     String profileImageUrl,
      String memberName,
      String createdAt,
      Category category,
@@ -24,6 +25,7 @@ public record ReportDetail (
         return new ReportDetail(
                 report.getId(),
                 report.getChatSession().getClient().getName(),
+                report.getChatSession().getClient().getProfileImageUrl(),
                 report.getChatSession().getMember().getName(),
                 report.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 M월 d일 a h:mm")),
                 report.getCategory(),

--- a/src/main/java/edu/sookmyung/talktitude/report/dto/ReportList.java
+++ b/src/main/java/edu/sookmyung/talktitude/report/dto/ReportList.java
@@ -1,6 +1,5 @@
 package edu.sookmyung.talktitude.report.dto;
 
-import edu.sookmyung.talktitude.client.model.Client;
 import edu.sookmyung.talktitude.report.model.Category;
 import edu.sookmyung.talktitude.report.model.Report;
 import java.time.LocalDate;
@@ -15,13 +14,13 @@ public record ReportList (
      LocalDate createdAt
 ){
 
-    public static ReportList convertToDto(Report report, Client client) {
+    public static ReportList convertToDto(Report report) {
         return new ReportList(
                 report.getId(),
                 report.getChatSession().getClient().getName(),
                 report.getChatSession().getClient().getPhone(),
                 report.getCategory(),
-                client.getProfileImageUrl(),
+                report.getChatSession().getClient().getProfileImageUrl(),
                 report.getCreatedAt().toLocalDate()
         );
     }

--- a/src/main/java/edu/sookmyung/talktitude/report/dto/ReportListByClient.java
+++ b/src/main/java/edu/sookmyung/talktitude/report/dto/ReportListByClient.java
@@ -8,13 +8,15 @@ import java.time.format.DateTimeFormatter;
 public record ReportListByClient(
         Long id,
         String time,
-        Category category
+        Category category,
+        String summaryText
 ) {
     public static ReportListByClient convertToReportListByClient(Report report) {
         return new ReportListByClient(
                 report.getId(),
                 report.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 M월 d일 a h:mm")),
-                report.getCategory()
+                report.getCategory(),
+                report.getSummaryText()
         );
     }
 }

--- a/src/main/java/edu/sookmyung/talktitude/report/repository/ReportRepository.java
+++ b/src/main/java/edu/sookmyung/talktitude/report/repository/ReportRepository.java
@@ -18,7 +18,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     @Query("SELECT r FROM Report r WHERE r.chatSession.client.loginId = :loginId")
     List<Report> findByClientLoginId(@Param("loginId") String loginId);
 
-    @Query("SELECT r FROM Report r WHERE (LOWER(r.chatSession.client.loginId) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(r.chatSession.client.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND DATE(r.createdAt) = :targetDate")
+    @Query("SELECT r FROM Report r WHERE LOWER(r.chatSession.client.loginId) LIKE LOWER(CONCAT('%', :keyword, '%')) AND DATE(r.createdAt) = :targetDate")
     List<Report> findByClientLoginIdOrNameLikeAndCreatedAt(
             @Param("keyword") String keyword,
             @Param("targetDate") LocalDate targetDate

--- a/src/main/java/edu/sookmyung/talktitude/report/service/ReportService.java
+++ b/src/main/java/edu/sookmyung/talktitude/report/service/ReportService.java
@@ -8,7 +8,6 @@ import edu.sookmyung.talktitude.chat.model.ChatMessage;
 import edu.sookmyung.talktitude.chat.model.ChatSession;
 import edu.sookmyung.talktitude.chat.model.Status;
 import edu.sookmyung.talktitude.chat.repository.ChatSessionRepository;
-import edu.sookmyung.talktitude.client.model.Client;
 import edu.sookmyung.talktitude.common.exception.BaseException;
 import edu.sookmyung.talktitude.common.exception.ErrorCode;
 import edu.sookmyung.talktitude.config.ai.GPTProperties;
@@ -156,10 +155,7 @@ public class ReportService {
 
         return reportRepository.findByCreatedAtBetween(startOfDay,endOfDay)
                 .stream()
-                .map(report->{
-                    Client client = report.getChatSession().getClient();
-                    return ReportList.convertToDto(report, client);
-                })
+                .map(ReportList::convertToDto)
                 .collect(Collectors.toList());
 
     }
@@ -175,10 +171,7 @@ public class ReportService {
     public List<ReportList> searchReportLists(String keyword, LocalDate targetDate) {
         return reportRepository.findByClientLoginIdOrNameLikeAndCreatedAt(keyword,targetDate)
                 .stream()
-                .map(report->{
-                    Client client = report.getChatSession().getClient();
-                    return ReportList.convertToDto(report, client);
-                })
+                .map(ReportList::convertToDto)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
#52 

## ✅ 작업 내용
- 3001번 포트 열기
- 검색 -> 아이디 검색만 허용하기
- 리포트 상세 내역에 프로필 이미지 추가하기
- 상담 이력 요청 시 바로 요약 정보도 넘겨주기
- 주문내역 데이터 & 메모 데이터 넣기

## 📸 스크린샷(선택)
- 리포트 상세 내역에 프로필 이미지 추가하기
- 
<img width="727" height="1188" alt="image" src="https://github.com/user-attachments/assets/0c66d23e-0a93-4174-87db-c930584c3175" />

- 상담 이력 요청 시 바로 요약 정보도 넘겨주기
<img width="668" height="531" alt="image" src="https://github.com/user-attachments/assets/a63057ed-eb59-4641-9b8d-7e4a0253af44" />

## 💬 리뷰 참고 사항
3001번 포트를 SecurityConfig에서 열었는데 혹시 코드가 틀렸다면 말씀해주세요! 
