### PR TITLE
[FIX]: 상담 상세 페이지에 세션 ID 추가

### DIFF
--- a/src/main/java/edu/sookmyung/talktitude/report/dto/ReportDetail.java
+++ b/src/main/java/edu/sookmyung/talktitude/report/dto/ReportDetail.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public record ReportDetail (
      Long id,
+     Long sessionId,
      String clientName,
      String profileImageUrl,
      String memberName,
@@ -24,6 +25,7 @@ public record ReportDetail (
     public static ReportDetail convertToReportDetail(Report report, List<MemoResponse> memos) {
         return new ReportDetail(
                 report.getId(),
+                report.getChatSession().getId(),
                 report.getChatSession().getClient().getName(),
                 report.getChatSession().getClient().getProfileImageUrl(),
                 report.getChatSession().getMember().getName(),


### PR DESCRIPTION
## 📌 관련 이슈
#52 


## ✅ 작업 내용
상담 상세 페이지에 세션 ID 추가 


## 📸 스크린샷(선택)
<img width="736" height="1160" alt="image" src="https://github.com/user-attachments/assets/431bb50f-04fb-401e-a518-4dcbac60456f" />


## 💬 리뷰 참고 사항

