### PR TITLE
FIX : 웹소켓 /ws 엔드포인트 permitAll로 교체

### DIFF
--- a/src/main/java/edu/sookmyung/talktitude/config/security/SecurityConfig.java
+++ b/src/main/java/edu/sookmyung/talktitude/config/security/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                         // CORS preflight(OPTIONS) 허용 — 문제 생기면 추가
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 
+                        // REVIEW /ws/info가 SockJS에서 자동으로 보내는 사전 확인용 요청이지만 성공하면 -> /ws.. 로 추가적인 요청이 이루어진다고 해서 /ws/**를 열어두었습니다(커스텀 헤더 설정 불가능) -> 혹시 아니라면 말씀해주세요
+                        .requestMatchers("/ws/**").permitAll()
                         // 비인증 허용 API
                         .requestMatchers("/members/**", "/clients/**", "/reports/run").permitAll()
 


### PR DESCRIPTION
## 📌 관련 이슈
#61 

## ✅ 작업 내용
/ws 엔드포인트 인증 필터 우회


## 📸 스크린샷(선택)


## 💬 리뷰 참고 사항
혹시 틀린 내용이거나, 다른 부분 수정해야 한다면 말씀해주세요
