### PR TITLE
[FIX] SockJS의 사전 확인 요청 토큰 없이 통과

### DIFF
--- a/src/main/java/edu/sookmyung/talktitude/config/websocket/HandShakeInterceptor.java
+++ b/src/main/java/edu/sookmyung/talktitude/config/websocket/HandShakeInterceptor.java
@@ -2,6 +2,7 @@ package edu.sookmyung.talktitude.config.websocket;
 
 import edu.sookmyung.talktitude.config.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,17 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
                                    WebSocketHandler wsHandler, Map<String, Object> attributes) {
 
+        // 1) CORS preflight(OPTIONS) 또는 SockJS info 요청은 무조건 통과
+        String path = request.getURI() != null ? request.getURI().getPath() : "";
+        if (request.getMethod() == HttpMethod.OPTIONS) {
+            return true;
+        }
+        // SockJS 사전 확인: GET /ws/info (또는 /ws/info?...)
+        if (path != null && path.contains("/ws/info")) {
+            return true;
+        }
+
+        // 2) 실제 핸드셰이크 단계에서만 토큰 검사
         String auth  = request.getHeaders().getFirst("Authorization");
         String token = (auth != null && auth.startsWith("Bearer ")) ? auth.substring(7) : null;
 
@@ -29,6 +41,8 @@ public class HandShakeInterceptor implements HandshakeInterceptor {
             attributes.put("loginId",  tokenProvider.getLoginId(token));    // String (Principal용)
             return true;
         }
+
+        // 토큰 없거나 유효하지 않으면 연결 거절
         return false;
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
  closed #63 


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- SockJS의 GET /ws/info 같은 사전 확인 요청은 토큰 없이 통과
- 실제 handshake 단계에서만 토큰 검사하도록 수정
 

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
